### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,38 @@
 https://github.com/microsoft/vscode/blob/main/ThirdPartyNotices.txt
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+# #D-Series
+
+[D-Series](<https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/#D-Series>)
+
+```markdown
+  General purpose compute
+  The D-series Azure VMs offer a combination of vCPUs, memory, and temporary storage able to meet the requirements associated with most production workloads.
+  
+  The Dv3 virtual machines are hyper-threaded general-purpose VMs based on the 2.3 GHz Intel® XEON ® E5-2673 v4 (Broadwell) processor. They can achieve 3.5 GHz with Intel     
+  Turbo Boost Technology 2.0.
+  
+  The Dv4 and Ddv4 virtual machines are based on a custom Intel® Xeon® Platinum 8272CL processor, which runs at a base speed of 2.5Ghz and can achieve up to 3.4Ghz all core 
+  turbo frequency. The Dd v4 virtual machine sizes feature fast, large local SSD storage (up to 2,400 GiB) and are well suited for applications that benefit from low latency, 
+  high-speed local storage. The Dv4 virtual machine sizes do not have any temporary storage.
+  
+  The Dv5 and Ddv5 series virtual machines feature the 3rd Generation Intel® Xeon® Platinum 8370C (Ice Lake) processor in a hyper-threaded configuration. They can scale up to 
+  96 vCPUs with configurations similar to the Dv4 and Ddv4 series VMs.
+  
+  The Dav4 and Dasv4 Azure VM-series provide up to 96 vCPUs, 384 GiBs of RAM and 2,400 GiBs of SSD-based temporary storage and feature the AMD EPYC™ 7452 processor.
+  
+  The Dasv5 and Dadsv5-series virtual machines are based on the 3rd Generation AMD EPYC™ 7763v (Milan) processor. This processor can achieve a boosted maximum frequency of 
+  3.5GHz. The VM series provide sizes with (Dadsv5) and without local temporary storage (Dasv5), and a better value proposition for most general-purpose workloads compared to 
+  the prior Dav4 and Dasv4 generation.
+  
+  The Dpsv5 and Dpdsv5 VM series feature the Ampere Altra 64-bit Multi-Core Arm-based processor operating at up to 3.0GHz frequency. The Ampere Altra processor was engineered 
+  for scale-out cloud environments and can deliver efficient performance to reduce overall environmental impact. The Dplsv5 and Dpldsv5 VM sizes offer one of the lowest price 
+  points of entry within the general-purpose Azure Virtual Machines portfolio, and provide 2GiBs per vCPU delivering a compelling value proposition for many general-purpose 
+  Linux workloads that do not require larger amounts of RAM per vCPU.
+  
+  The Ds, Dds, Das, Dads, Dps, Dpds, Dpls, and Dplds VM series support Azure Premium SSDs and Ultra Disk storage depending on regional availability.
+  
+  Example workloads include many enterprise-grade applications, e-commerce systems, web front ends, desktop virtualization solutions, customer relationship management 
+  applications, entry-level and mid-range databases, application servers, gaming servers, media servers, and more...
+```


### PR DESCRIPTION
```markdown
# License-Templates

## ![Visitors](https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2Fewdlop&countColor=%23263759) % max.

https://github.com/microsoft/vscode/blob/main/ThirdPartyNotices.txt

Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

# #D-Series

[D-Series](<https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/#D-Series>)

```markdown
  General purpose compute
  The D-series Azure VMs offer a combination of vCPUs, memory, and temporary storage able to meet the requirements associated with most production workloads.
  
  The Dv3 virtual machines are hyper-threaded general-purpose VMs based on the 2.3 GHz Intel® XEON ® E5-2673 v4 (Broadwell) processor. They can achieve 3.5 GHz with Intel     
  Turbo Boost Technology 2.0.
  
  The Dv4 and Ddv4 virtual machines are based on a custom Intel® Xeon® Platinum 8272CL processor, which runs at a base speed of 2.5Ghz and can achieve up to 3.4Ghz all core 
  turbo frequency. The Dd v4 virtual machine sizes feature fast, large local SSD storage (up to 2,400 GiB) and are well suited for applications that benefit from low latency, 
  high-speed local storage. The Dv4 virtual machine sizes do not have any temporary storage.
  
  The Dv5 and Ddv5 series virtual machines feature the 3rd Generation Intel® Xeon® Platinum 8370C (Ice Lake) processor in a hyper-threaded configuration. They can scale up to 
  96 vCPUs with configurations similar to the Dv4 and Ddv4 series VMs.
  
  The Dav4 and Dasv4 Azure VM-series provide up to 96 vCPUs, 384 GiBs of RAM and 2,400 GiBs of SSD-based temporary storage and feature the AMD EPYC™ 7452 processor.
  
  The Dasv5 and Dadsv5-series virtual machines are based on the 3rd Generation AMD EPYC™ 7763v (Milan) processor. This processor can achieve a boosted maximum frequency of 
  3.5GHz. The VM series provide sizes with (Dadsv5) and without local temporary storage (Dasv5), and a better value proposition for most general-purpose workloads compared to 
  the prior Dav4 and Dasv4 generation.
  
  The Dpsv5 and Dpdsv5 VM series feature the Ampere Altra 64-bit Multi-Core Arm-based processor operating at up to 3.0GHz frequency. The Ampere Altra processor was engineered 
  for scale-out cloud environments and can deliver efficient performance to reduce overall environmental impact. The Dplsv5 and Dpldsv5 VM sizes offer one of the lowest price 
  points of entry within the general-purpose Azure Virtual Machines portfolio, and provide 2GiBs per vCPU delivering a compelling value proposition for many general-purpose 
  Linux workloads that do not require larger amounts of RAM per vCPU.
  
  The Ds, Dds, Das, Dads, Dps, Dpds, Dpls, and Dplds VM series support Azure Premium SSDs and Ultra Disk storage depending on regional availability.
  
  Example workloads include many enterprise-grade applications, e-commerce systems, web front ends, desktop virtualization solutions, customer relationship management 
  applications, entry-level and mid-range databases, application servers, gaming servers, media servers, and more...
```